### PR TITLE
PX-1070 Update Dockerfile to include the right dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
 FROM ebot7/eb7_sls_helper:test
 
-ENV PYTHONPATH "${PYTHONPATH}:/usr/bin/"
 CMD python3 /usr/bin/eb7_sls_helper/src/gh_action_interface.py

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,8 +1,10 @@
-FROM python:alpine3.11
+FROM python:3.8-slim
 
-RUN pip install pyyaml boto3 tox
-RUN apk add npm
-RUN apk add git
+RUN pip install --upgrade pip tox virtualenv pyyaml boto3
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt-get install -y nodejs git
 RUN npm install -g serverless
 RUN npm install serverless-domain-manager serverless-manifest-plugin
 RUN npm install -g newman 
@@ -10,5 +12,4 @@ RUN npm install -g newman
 COPY eb7_sls_helper/ /usr/bin/eb7_sls_helper/
 ENV PYTHONPATH "${PYTHONPATH}:/usr/bin/"
 
-# Entrypoint
 CMD python3 /usr/bin/eb7_sls_helper/src/gh_action_interface.py


### PR DESCRIPTION
### Q: Why did we change from alpine to debian base image:
### A: Its not recommended because:
1. Make your builds much slower.
2. Make your images bigger.
3. On occasions, introduce obscure runtime bugs.

> You can read about this more in this [article](https://pythonspeed.com/articles/alpine-docker-python/)
